### PR TITLE
Add deprecation message to mappings.json files

### DIFF
--- a/deploy/terraform/data/mappings.json
+++ b/deploy/terraform/data/mappings.json
@@ -1,4 +1,5 @@
 {
+  "__________DEPRECATED_AND_MOVED_TO_DATA_DICTIONARY___________": true,
   "specVersion": "1",
   "mappings": [
     {


### PR DESCRIPTION
Integration-specific mapping files have been moved to the https://github.com/JupiterOne/data-dictionary project. At some point in the near future, the mapper will no longer look at the S3 bucket this project uploads to, and instead look at the S3 bucket the data-dictionary uploads to.